### PR TITLE
Convert run from positional to named argument for consistency

### DIFF
--- a/inpars/evaluate.py
+++ b/inpars/evaluate.py
@@ -41,7 +41,7 @@ def run_trec_eval(run_file, qrels_file, relevance_threshold=1):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("run", type=str)
+    parser.add_argument("--run", type=str, required=True)
     parser.add_argument("--dataset", default="msmarco")
     parser.add_argument("--qrels", default=None)
     parser.add_argument("--relevance_threshold", default=1)


### PR DESCRIPTION
In the evaluate.py script, the **run** argument was defined as a positional argument, which didn't match with the example usage in the [README](https://github.com/zetaalphavector/InPars/blob/4e9e46386d67ed9c97493195a0a491229f69b1d4/README.md#usage). I changed it to a named argument (`--run`) and made it required so it can be used as described.