### PR TITLE
Fix error

### DIFF
--- a/inpars/generate_triples.py
+++ b/inpars/generate_triples.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
             corpus = pd.read_json(args.input, lines=True)
     else:
         corpus = load_corpus(args.dataset, source=args.dataset_source)
-        index = f'beir-v1.0.0-{args.dataset}-flat'
+        index = f'beir-v1.0.0-{args.dataset}.flat'
 
     # Convert to {'doc_id': 'text'} format
     corpus = dict(zip(corpus['doc_id'], corpus['text']))


### PR DESCRIPTION
I discovered an error in the code where the prebuilt index in referenced as `f'beir-v1.0.0-{args.dataset}-flat'`. According to the pyserini documentation, the correct format for the prebuilt index should be `.flat`, as in `beir-v1.0.0-{args.dataset}.flat`.
For example `beir-v1.0.0-trec-covid.flat` instead of `beir-v1.0.0-trec-covid-flat`.